### PR TITLE
Update vue to use 3.0.0

### DIFF
--- a/templates/app-template-vue/package.json
+++ b/templates/app-template-vue/package.json
@@ -22,7 +22,7 @@
     "jest": "^25.4.0",
     "parcel-bundler": "^1.12.4",
     "snowpack": "^2.0.0-0",
-    "vue": "^2.0.0"
+    "vue": "^3.0.0-beta.9"
   },
   "gitHead": "YYY"
 }


### PR DESCRIPTION
@vue SFC compiler is supported for Vue 3.0 (Currently in Beta)

Package version from [create-vite-app](https://github.com/vuejs/vite/blob/a135bfd32b1a468cfc91cd88b6df17c8be873f3c/create-vite-app/template/_package.json#L9)

Closes #5 