### PR TITLE
fix(react-ts): move react deps to webDependencies

### DIFF
--- a/templates/app-template-react-typescript/package.json
+++ b/templates/app-template-react-typescript/package.json
@@ -15,7 +15,9 @@
     "test": "jest"
   },
   "webDependencies": {
-    "csz": "^1.2.0"
+    "csz": "^1.2.0",
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0"
   },
   "devDependencies": {
     "@snowpack/app-scripts-react": "^0.2.4",
@@ -23,8 +25,6 @@
     "@testing-library/react": "^10.0.3",
     "jest": "^25.4.0",
     "parcel-bundler": "^1.12.4",
-    "react": "^16.13.0",
-    "react-dom": "^16.13.0",
     "snowpack": "^2.0.0-0",
     "typescript": "^3.8.0"
   },

--- a/templates/app-template-react-typescript/package.json
+++ b/templates/app-template-react-typescript/package.json
@@ -24,7 +24,7 @@
     "jest": "^25.4.0",
     "parcel-bundler": "^1.12.4",
     "react": "^16.13.0",
-    "react-dom": "^16.13.0"
+    "react-dom": "^16.13.0",
     "snowpack": "^2.0.0-0",
     "typescript": "^3.8.0"
   },

--- a/templates/app-template-react-typescript/package.json
+++ b/templates/app-template-react-typescript/package.json
@@ -15,9 +15,7 @@
     "test": "jest"
   },
   "webDependencies": {
-    "csz": "^1.2.0",
-    "react": "^16.13.0",
-    "react-dom": "^16.13.0"
+    "csz": "^1.2.0"
   },
   "devDependencies": {
     "@snowpack/app-scripts-react": "^0.2.4",
@@ -25,6 +23,8 @@
     "@testing-library/react": "^10.0.3",
     "jest": "^25.4.0",
     "parcel-bundler": "^1.12.4",
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0"
     "snowpack": "^2.0.0-0",
     "typescript": "^3.8.0"
   },

--- a/templates/app-template-react-typescript/src/App.tsx
+++ b/templates/app-template-react-typescript/src/App.tsx
@@ -8,7 +8,7 @@ function App() {
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
         <p>
-          Edit <code>src/App.jsx</code> and save to reload.
+          Edit <code>src/App.tsx</code> and save to reload.
         </p>
         <a
           className="App-link"

--- a/templates/app-template-react-typescript/src/index.tsx
+++ b/templates/app-template-react-typescript/src/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import App from "./App.jsx";
+import App from "./App";
 import "./index.css";
 
 ReactDOM.render(


### PR DESCRIPTION
This was necessary for me to see the app load on the page. A blank screen would be shown otherwise, with an error in the console:

```
TypeError: Z is undefinedreact-dom.js:340:200
    React 3
        reactDom_production_min
        reactDom_production_min
        reactDom_production_min
    createCommonjsModule http://localhost:3000/web_modules/common/_commonjsHelpers-f5462f22.js:4
    <anonymous> React
    InnerModuleEvaluation self-hosted:1604
    InnerModuleEvaluation self-hosted:1593
    evaluation self-hosted:1558
```

The removal of the extension in `index.tsx`  was necessary for `lintall:tsc` not to complain.

I believe a similar fix should be done in the React template.