### PR TITLE
Replace React with Preact on app-template-preact/README

### DIFF
--- a/templates/app-template-preact/README.md
+++ b/templates/app-template-preact/README.md
@@ -20,7 +20,7 @@ See the section about running tests for more information.
 ### npm run build
 
 Builds the app for production to the `build/` folder.
-It correctly bundles React in production mode and optimizes the build for the best performance.
+It correctly bundles Preact in production mode and optimizes the build for the best performance.
 
 The build is minified and the filenames include the hashes.
 Your app is ready to be deployed!


### PR DESCRIPTION
Hello!

This PR fixes a small typo on the `app-template-preact/README.md` file.  It basically replaces "React" with "Preact" 😛 