### PR TITLE
Provide filename argument to svelte.preprocess.

### DIFF
--- a/packages/plugin-svelte/plugin.js
+++ b/packages/plugin-svelte/plugin.js
@@ -17,7 +17,8 @@ exports.build = async function build(fileLoc) {
   if (preprocessOptions) {
     ({ code: codeToCompile } = await svelte.preprocess(
       fileSource,
-      preprocessOptions
+      preprocessOptions,
+      { filename: fileLoc }
     ));
   }
   // COMPILE


### PR DESCRIPTION
This provides the `filename` argument to `svelte.preprocess`, which some preprocessors require.