### PR TITLE
Fix reference error

### DIFF
--- a/packages/plugin-svelte/plugin.js
+++ b/packages/plugin-svelte/plugin.js
@@ -30,7 +30,7 @@ module.exports = function plugin(config, pluginOptions) {
       if (preprocessOptions) {
         codeToCompile = (
           await svelte.preprocess(codeToCompile, preprocessOptions, {
-            filename: fileLoc,
+            filename: filePath,
           })
         ).code;
       }


### PR DESCRIPTION
[error] C:\dev\learn\snowpack2\src\App.svelte ReferenceError: fileLoc is not defined
      at build (C:\dev\learn\snowpack2\node_modules\@snowpack\plugin-svelte\plugin.js:33:23)