### PR TITLE
make @snowpack/plugin-babel compatible with v2

### DIFF
--- a/packages/plugin-babel/plugin.js
+++ b/packages/plugin-babel/plugin.js
@@ -3,11 +3,14 @@ const babel = require("@babel/core");
 module.exports = function plugin(config, options) {
   return {
     defaultBuildScript: "build:js,jsx,ts,tsx",
-    async build({ fileContents, filePath }) {
-      const result = await babel.transformAsync(fileContents, {
+    async build({ contents, filePath, fileContents }) {
+      const result = await babel.transformAsync(contents || fileContents, {
         filename: filePath,
         cwd: process.cwd(),
+        ast: false,
+        sourceMaps: false,
       });
+
       return { result: result.code };
     },
   };

--- a/packages/plugin-babel/plugin.js
+++ b/packages/plugin-babel/plugin.js
@@ -8,7 +8,6 @@ module.exports = function plugin(config, options) {
         filename: filePath,
         cwd: process.cwd(),
         ast: false,
-        sourceMaps: false,
       });
 
       return { result: result.code };


### PR DESCRIPTION
Disabling ast-generation increases speed of the total transformation time.