### PR TITLE
Added extendConfig plugin option to plugin-bundle-webpack

### DIFF
--- a/packages/plugin-bundle-webpack/package.json
+++ b/packages/plugin-bundle-webpack/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@snowpack/plugin-bundle-webpack",
+  "version": "0.6.1",
+  "main": "plugin.js",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "babel-loader": "^8.1.0",
+    "copy-webpack-plugin": "^6.0.1",
+    "css-loader": "^3.5.3",
+    "file-loader": "^6.0.0",
+    "jsdom": "^16.2.2",
+    "mini-css-extract-plugin": "^0.9.0",
+    "webpack": "^4.43.0"
+  }
+}

--- a/packages/plugin-bundle-webpack/plugin.js
+++ b/packages/plugin-bundle-webpack/plugin.js
@@ -24,6 +24,13 @@ module.exports = function plugin(config, args) {
       let homepage = config.homepage || "";
       let fallback = config.devOptions?.fallback || "index.html";
 
+      let extendConfig = (cfg) => cfg;
+      if (typeof args.extendConfig === "function") {
+        extendConfig = args.extendConfig;
+      } else if (typeof args.extendConfig === "object") {
+        extendConfig = (cfg) => ({ ...cfg, ...args.extendConfig });
+      }
+
       let dom = new JSDOM(
         fs.readFileSync(path.join(srcDirectory, config.devOptions.fallback))
       );
@@ -109,14 +116,16 @@ module.exports = function plugin(config, args) {
         ],
       };
 
-      const stats = await compilePromise({
-        ...webpackConfig,
-        entry: path.join(srcDirectory, entryPoint),
-        output: {
-          path: destDirectory,
-          filename: "js/bundle-[hash].js",
-        },
-      }).catch((err) => {
+      const stats = await compilePromise(
+        extendConfig({
+          ...webpackConfig,
+          entry: path.join(srcDirectory, entryPoint),
+          output: {
+            path: destDirectory,
+            filename: "js/bundle-[hash].js",
+          },
+        })
+      ).catch((err) => {
         console.log(err);
       });
 

--- a/packages/plugin-bundle-webpack/plugin.js
+++ b/packages/plugin-bundle-webpack/plugin.js
@@ -75,7 +75,7 @@ module.exports = function plugin(config, args) {
               ],
             },
             {
-              test: /\.(svg|png|jpe?g|gif)$/, //We can expand this list of importable files
+              test: /\.*/, //We can expand this list of importable files
               use: [
                 {
                   loader: "file-loader",

--- a/packages/plugin-bundle-webpack/plugin.js
+++ b/packages/plugin-bundle-webpack/plugin.js
@@ -75,7 +75,8 @@ module.exports = function plugin(config, args) {
               ],
             },
             {
-              test: /\.*/, //We can expand this list of importable files
+              test: /\.*$/,
+              exclude: [/\.jsx?$/, /\.s?css$/],
               use: [
                 {
                   loader: "file-loader",

--- a/packages/plugin-bundle-webpack/plugin.js
+++ b/packages/plugin-bundle-webpack/plugin.js
@@ -1,0 +1,139 @@
+const fs = require("fs");
+const path = require("path");
+const webpack = require("webpack");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const jsdom = require("jsdom");
+const CopyPlugin = require("copy-webpack-plugin");
+const { JSDOM } = jsdom;
+
+async function compilePromise(webpackConfig) {
+  const compiler = webpack(webpackConfig);
+  return new Promise((resolve, reject) => {
+    compiler.run((err, stats) => {
+      if (stats.hasErrors()) {
+        reject(err);
+      }
+      resolve(stats);
+    });
+  });
+}
+
+module.exports = function plugin(config, args) {
+  return {
+    async bundle({ srcDirectory, destDirectory, log, jsFilePaths }) {
+      let homepage = config.homepage || "";
+      let fallback = config.devOptions?.fallback || "index.html";
+
+      let dom = new JSDOM(
+        fs.readFileSync(path.join(srcDirectory, config.devOptions.fallback))
+      );
+
+      //Find the first local script, assume it's the entrypoint
+      let scriptEl;
+      for (const el of Array.from(
+        dom.window.document.querySelectorAll("script")
+      )) {
+        let src = el.src.trim();
+        if (
+          el.type.trim().toLowerCase() === "module" &&
+          !src.trim().match(/[a-zA-Z+]+:\/\//g)
+        ) {
+          scriptEl = el;
+          break;
+        }
+      }
+      if (!scriptEl) {
+        throw new Error("Can't bundle without script tag in html");
+      }
+      let entryPoint = scriptEl.src;
+
+      //Compile files using webpack
+      let webpackConfig = {
+        resolve: {
+          alias: {
+            "/web_modules": path.join(srcDirectory, "web_modules/"),
+          },
+        },
+        module: {
+          rules: [
+            {
+              test: /\.jsx?$/,
+              exclude: ["/node_modules/"],
+              use: {
+                loader: "babel-loader",
+              },
+            },
+            {
+              test: /\.s?css$/,
+              use: [
+                {
+                  loader: MiniCssExtractPlugin.loader,
+                },
+                {
+                  loader: "css-loader",
+                },
+              ],
+            },
+            {
+              test: /\.(svg|png|jpe?g|gif)$/, //We can expand this list of importable files
+              use: [
+                {
+                  loader: "file-loader",
+                  options: {
+                    name: "assets/[name]-[hash].[ext]",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        mode: "production",
+        plugins: [
+          //Extract a css file from imported css files
+          new MiniCssExtractPlugin({
+            filename: "css/style-[hash].css",
+          }),
+          //Copy other files to the destination, excluding ones that are no longer useful
+          new CopyPlugin({
+            patterns: [
+              {
+                from: srcDirectory,
+                to: destDirectory,
+                globOptions: {
+                  ignore: [`/${fallback}`, "**/_dist_/**", "**/web_modules/**"],
+                },
+              },
+            ],
+          }),
+        ],
+      };
+
+      const stats = await compilePromise({
+        ...webpackConfig,
+        entry: path.join(srcDirectory, entryPoint),
+        output: {
+          path: destDirectory,
+          filename: "js/bundle-[hash].js",
+        },
+      }).catch((err) => {
+        console.log(err);
+      });
+
+      //Now that webpack is done, modify the html file to point to the newly compiled resources
+      scriptEl.src = path.join(homepage, `/js/bundle-${stats.hash}.js`);
+      let hasCSS = Object.keys(stats.compilation.assets).some((d) =>
+        d.endsWith(".css")
+      );
+
+      if (hasCSS) {
+        let csslink = dom.window.document.createElement("link");
+        csslink.setAttribute("rel", "stylesheet");
+        csslink.href = path.join(homepage, `/css/style-${stats.hash}.css`);
+        dom.window.document.querySelector("head").append(csslink);
+      }
+
+      //And write our modified html file out to the destination
+      fs.writeFileSync(path.join(destDirectory, fallback), dom.serialize());
+    },
+  };
+};

--- a/packages/plugin-bundle-webpack/plugin.js
+++ b/packages/plugin-bundle-webpack/plugin.js
@@ -75,7 +75,7 @@ module.exports = function plugin(config, args) {
               ],
             },
             {
-              test: /\.*$/,
+              test: /.*/,
               exclude: [/\.jsx?$/, /\.s?css$/],
               use: [
                 {


### PR DESCRIPTION
I added the extendConfig plugin option. Here, both these versions should do the same thing:

snowpack.config.json:
```
{
  extends: '@snowpack/app-scripts-react',
  devOptions: { bundle: true },
  plugins: [
    [
      '@snowpack/plugin-bundle-webpack',
      {
        extendConfig: {
          devtool: 'source-map',
          mode: 'development'
        }
      },
    ],
  ],
  scripts: { 'bundle:*': '@snowpack/plugin-bundle-webpack' },
}
```
AND

snowpack.config.js:
```
module.exports = {
  extends: '@snowpack/app-scripts-react',
  devOptions: { bundle: true },
  plugins: [
    [
      '@snowpack/plugin-bundle-webpack',
      {
        extendConfig: (config) => ({
          ...config,
          devtool: 'source-map',
          mode: 'development',
        }),
      },
    ],
  ],
  scripts: { 'bundle:*': '@snowpack/plugin-bundle-webpack' },
};
```