### PR TITLE
add HMR support to react, svelte, and vue templates

### DIFF
--- a/templates/app-template-lit-element-typescript/types/import.d.ts
+++ b/templates/app-template-lit-element-typescript/types/import.d.ts
@@ -1,0 +1,7 @@
+// ESM-HMR Interface: `import.meta.hot`
+
+interface ImportMeta {
+  // TODO: Import the exact .d.ts files from "esm-hmr"
+  // https://github.com/pikapkg/esm-hmr
+  hot: any;
+}

--- a/templates/app-template-react-typescript/src/index.tsx
+++ b/templates/app-template-react-typescript/src/index.tsx
@@ -9,3 +9,9 @@ ReactDOM.render(
   </React.StrictMode>,
   document.getElementById('root'),
 );
+
+// Hot Module Replacement (HMR) - Remove this snippet to remove HMR.
+// Learn more: https://www.snowpack.dev/#hot-module-replacement
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/templates/app-template-react-typescript/types/import.d.ts
+++ b/templates/app-template-react-typescript/types/import.d.ts
@@ -1,0 +1,7 @@
+// ESM-HMR Interface: `import.meta.hot`
+
+interface ImportMeta {
+  // TODO: Import the exact .d.ts files from "esm-hmr"
+  // https://github.com/pikapkg/esm-hmr
+  hot: any;
+}

--- a/templates/app-template-react/src/index.jsx
+++ b/templates/app-template-react/src/index.jsx
@@ -9,3 +9,9 @@ ReactDOM.render(
   </React.StrictMode>,
   document.getElementById('root'),
 );
+
+// Hot Module Replacement (HMR) - Remove this snippet to remove HMR.
+// Learn more: https://www.snowpack.dev/#hot-module-replacement
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}

--- a/templates/app-template-svelte/src/index.js
+++ b/templates/app-template-svelte/src/index.js
@@ -5,3 +5,12 @@ var app = new App({
 });
 
 export default app;
+
+// Hot Module Replacement (HMR) - Remove this snippet to remove HMR.
+// Learn more: https://www.snowpack.dev/#hot-module-replacement
+if (import.meta.hot) {
+  import.meta.hot.accept();
+  import.meta.hot.dispose(() => {
+    app.$destroy();
+  });
+}

--- a/templates/app-template-vue/src/index.js
+++ b/templates/app-template-vue/src/index.js
@@ -1,4 +1,14 @@
 import { createApp } from "vue";
 import App from "./App.vue";
 
-createApp(App).mount("#app");
+const app = createApp(App);
+app.mount("#app");
+
+// Hot Module Replacement (HMR) - Remove this snippet to remove HMR.
+// Learn more: https://www.snowpack.dev/#hot-module-replacement
+if (import.meta.hot) {
+  import.meta.hot.accept();
+  import.meta.hot.dispose(() => {
+    app.unmount();
+  });
+}


### PR DESCRIPTION
/cc @JoviDeCroock @rixo

This adds basic HMR support to the templates mentioned in the title. In all 3 templates, we place an `import.meta.hot.accept()` call at the application root that will catch all updates, reload any updated files, dispose the old app (if needed) and then finally remount the app without triggering a full page load.

This builds on our work in https://github.com/pikapkg/esm-hmr, and requires `snowpack@2.0.0-rc.3` or higher to run properly.