### PR TITLE
fix typescript support for preact template

### DIFF
--- a/packages/app-scripts-preact/babel.config.json
+++ b/packages/app-scripts-preact/babel.config.json
@@ -7,7 +7,12 @@
         "pragmaFrag": "Fragment"
       }
     ],
-    "@babel/preset-typescript"
+    [
+      "@babel/preset-typescript",
+      {
+        "jsxPragma": "h"
+      }
+    ]
   ],
   "plugins": ["@babel/plugin-syntax-import-meta"],
   "env": {


### PR DESCRIPTION
This PR fixes TypeScript support for projects using the Preact template

According to the [docs](https://babeljs.io/docs/en/babel-preset-typescript) for `@babel/preset-typescript`

> - `jsxPragma` - defaults to `React`  
>   Replace the function used when compiling JSX expressions. This is so that we know that the import is not a type import, and should not be removed.

Changing this to `h` solves the issue.

This doesn't solve the issue for Parcel bundler though, as adding `@snowpack/plugin-parcel` to the project's config will remove all the plugins from the config that it's extending from, this is a separate issue however.
