### PR TITLE
Do not give an error when only index.html exists

### DIFF
--- a/packages/plugin-webpack/plugin.js
+++ b/packages/plugin-webpack/plugin.js
@@ -177,6 +177,7 @@ module.exports = function plugin(config, args) {
                     "**/web_modules/**",
                   ],
                 },
+                noErrorOnMissing: true,
               },
             ],
           }),


### PR DESCRIPTION
The build with `@snowpack/plugin-webpack` will fail if there are no files other than index.html in the public directory.

Repository for reproduction:
https://github.com/yuheiy/create-snowpack-app-plugin-webpack-only-index.html

Set the `noErrorOnMissing` option to `copy-webpack-plugin` to fix the problem.