### PR TITLE
add spacing for console messages post success

### DIFF
--- a/packages/create-snowpack-app/index.js
+++ b/packages/create-snowpack-app/index.js
@@ -165,10 +165,13 @@ if (requiredVersion < 10) {
   console.log(`  ${useYarn ? "yarn" : "npm"} install`);
   console.log(`  ${chalk.dim("Install your dependencies.")}`);
   console.log(`  ${chalk.dim("We already ran this one for you!")}`);
+  console.log(``);
   console.log(`  ${useYarn ? "yarn" : "npm"} start`);
   console.log(`  ${chalk.dim("Start your development server.")}`);
+  console.log(``);
   console.log(`  ${useYarn ? "yarn" : "npm run"} build`);
   console.log(`  ${chalk.dim("Build your website for production.")}`);
+  console.log(``);
   console.log(`  ${useYarn ? "yarn" : "npm"} test`);
   console.log(`  ${chalk.dim("Run your tests.")}`);
   console.log(``);


### PR DESCRIPTION
Currently, the post install success messages don't have adequate spacing between them:

<img width="288" alt="image" src="https://user-images.githubusercontent.com/11270438/83104270-05dc7180-a0d6-11ea-927d-35fd75aa871a.png">

This PR adds new lines to make them easier to read.