### PR TITLE
Add resolveJsonModule to template's tsconfigs

### DIFF
--- a/packages/app-scripts-lit-element/tsconfig.base.json
+++ b/packages/app-scripts-lit-element/tsconfig.base.json
@@ -12,6 +12,7 @@
     /* Additional Options */
     "strict": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
   }
 }

--- a/packages/app-scripts-preact/tsconfig.base.json
+++ b/packages/app-scripts-preact/tsconfig.base.json
@@ -12,6 +12,7 @@
     /* Additional Options */
     "strict": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
   }
 }

--- a/packages/app-scripts-react/tsconfig.base.json
+++ b/packages/app-scripts-react/tsconfig.base.json
@@ -12,6 +12,7 @@
     /* Additional Options */
     "strict": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
This PR adds [`resolveJsonModule`](https://www.staging-typescript.org/tsconfig#resolveJsonModule) to tsconfig on every template:
  - `packages/app-scripts-lit-element/tsconfig.base.json` - used by `templates/app-template-lit-element-typescript/tsconfig.json`
  - `packages/app-scripts-preact/tsconfig.base.json`
  - `packages/app-scripts-react/tsconfig.base.json` - used by `templates/app-template-react-typescript/tsconfig.json`

There's no `app-template-preact-typescript` that will use `tsconfig.base.json` in `app-scripts-preact` yet.

Resolve https://github.com/pikapkg/create-snowpack-app/issues/90