### PR TITLE
Remove deprecated type usage

### DIFF
--- a/templates/app-template-react-typescript/src/App.tsx
+++ b/templates/app-template-react-typescript/src/App.tsx
@@ -4,7 +4,7 @@ import './App.css';
 
 interface AppProps {}
 
-function App({}: React.Props<AppProps>) {
+function App({}: AppProps) {
   return (
     <div className="App">
       <header className="App-header">


### PR DESCRIPTION
`React.Props` is deprecated and generally not used.

The most common approach is either to specify the exact props you want (`{ children: React.ReactNode }` or use the `React.FC<Props>` to type the entire function.