### PR TITLE
Update templates to use windows friendly scripts

### DIFF
--- a/templates/app-template-11ty/package.json
+++ b/templates/app-template-11ty/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "start": "snowpack dev",
     "build": "snowpack build",
-    "format": "prettier --write 'src/**/*.js'",
-    "lint": "prettier --check 'src/**/*.js'",
+    "format": "prettier --write \"src/**/*.js\"",
+    "lint": "prettier --check \"src/**/*.js\"",
     "test": "echo \"This template does not include a test runner by default.\" && exit 1"
   },
   "dependencies": {

--- a/templates/app-template-blank/package.json
+++ b/templates/app-template-blank/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "start": "snowpack dev",
     "build": "snowpack build",
-    "format": "prettier --write 'src/**/*.js'",
-    "lint": "prettier --check 'src/**/*.js'",
+    "format": "prettier --write \"src/**/*.js\"",
+    "lint": "prettier --check \"src/**/*.js\"",
     "test": "echo \"This template does not include a test runner by default.\" && exit 1"
   },
   "dependencies": {

--- a/templates/app-template-lit-element-typescript/package.json
+++ b/templates/app-template-lit-element-typescript/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "start": "snowpack dev",
     "build": "snowpack build",
-    "format": "prettier --write 'src/**/*.ts'",
-    "lint": "prettier --check 'src/**/*.ts'",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "lint": "prettier --check \"src/**/*.ts\"",
     "test": "echo \"This template does not include a test runner by default.\" && exit 1"
   },
   "dependencies": {

--- a/templates/app-template-lit-element/package.json
+++ b/templates/app-template-lit-element/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "start": "snowpack dev",
     "build": "snowpack build",
-    "format": "prettier --write 'src/**/*.js'",
-    "lint": "prettier --check 'src/**/*.js'",
+    "format": "prettier --write \"src/**/*.js\"",
+    "lint": "prettier --check \"src/**/*.js\"",
     "test": "echo \"This template does not include a test runner by default.\" && exit 1"
   },
   "dependencies": {

--- a/templates/app-template-preact/package.json
+++ b/templates/app-template-preact/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "start": "snowpack dev",
     "build": "snowpack build",
-    "format": "prettier --write 'src/**/*.{js,jsx}'",
-    "lint": "prettier --check 'src/**/*.{js,jsx}'",
+    "format": "prettier --write \"src/**/*.{js,jsx}\"",
+    "lint": "prettier --check \"src/**/*.{js,jsx}\"",
     "test": "jest"
   },
   "dependencies": {

--- a/templates/app-template-react-typescript/package.json
+++ b/templates/app-template-react-typescript/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "start": "snowpack dev",
     "build": "snowpack build",
-    "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx}'",
-    "lint": "prettier --check 'src/**/*.{js,jsx,ts,tsx}'",
+    "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
+    "lint": "prettier --check \"src/**/*.{js,jsx,ts,tsx}\"",
     "test": "jest"
   },
   "devDependencies": {

--- a/templates/app-template-react/package.json
+++ b/templates/app-template-react/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "start": "snowpack dev",
     "build": "snowpack build",
-    "format": "prettier --write 'src/**/*.{js,jsx}'",
-    "lint": "prettier --check 'src/**/*.{js,jsx}'",
+    "format": "prettier --write \"src/**/*.{js,jsx}\"",
+    "lint": "prettier --check \"src/**/*.{js,jsx}\"",
     "test": "jest"
   },
   "devDependencies": {


### PR DESCRIPTION
`'` causes issues on Windows. The solution is to use `\"` instead