### PR TITLE
add vue template preprocessor lang support

### DIFF
--- a/packages/plugin-vue/plugin.js
+++ b/packages/plugin-vue/plugin.js
@@ -48,6 +48,7 @@ module.exports = function plugin(config, pluginOptions) {
         const templateCode = compiler.compileTemplate({
           filename: filePath,
           source: descriptor.template.content,
+          preprocessLang: descriptor.template.lang,
           compilerOptions: {
             scopeId: descriptor.styles.some((s) => s.scoped)
               ? `data-v-${id}`


### PR DESCRIPTION
Support all template preprocessors that are supported by [`@vue/compiler-sfc`](https://www.npmjs.com/package/@vue/compiler-sfc) (uses https://github.com/tj/consolidate.js/ under the hood, see consolidate.js README for full list of languages).

Example using `pug`:

```vue
<template lang="pug">
.App
  a(href="//vuejs.org") Hi
</template>
```

```js
// package.json
"devDependencies": {
  // ...
  "pug": "^3.0.0"
}
```