### PR TITLE
Update import meta typing to include env

### DIFF
--- a/templates/app-template-lit-element-typescript/types/import.d.ts
+++ b/templates/app-template-lit-element-typescript/types/import.d.ts
@@ -4,4 +4,5 @@ interface ImportMeta {
   // TODO: Import the exact .d.ts files from "esm-hmr"
   // https://github.com/pikapkg/esm-hmr
   hot: any;
+  env: Record<string, any>;
 }

--- a/templates/app-template-react-typescript/types/import.d.ts
+++ b/templates/app-template-react-typescript/types/import.d.ts
@@ -4,4 +4,5 @@ interface ImportMeta {
   // TODO: Import the exact .d.ts files from "esm-hmr"
   // https://github.com/pikapkg/esm-hmr
   hot: any;
+  env: Record<string, any>;
 }


### PR DESCRIPTION
Looks like we forgot to add the `env` key to the `importMeta` type definition.

Brought up in https://github.com/pikapkg/snowpack/pull/394#issuecomment-639154557