### PR TITLE
Disable treeshaking for lit-html templates

### DIFF
--- a/templates/app-template-lit-element-typescript/package.json
+++ b/templates/app-template-lit-element-typescript/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "snowpack dev",
-    "build": "snowpack build",
+    "build": "snowpack build --no-treeshake",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "prettier --check \"src/**/*.ts\"",
     "test": "echo \"This template does not include a test runner by default.\" && exit 1"

--- a/templates/app-template-lit-element/package.json
+++ b/templates/app-template-lit-element/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "snowpack dev",
-    "build": "snowpack build",
+    "build": "snowpack build --no-treeshake",
     "format": "prettier --write \"src/**/*.js\"",
     "lint": "prettier --check \"src/**/*.js\"",
     "test": "echo \"This template does not include a test runner by default.\" && exit 1"


### PR DESCRIPTION
From https://www.pika.dev/npm/snowpack/discuss/364, Snowpack tries to treeshake out side-effects from Web Component packages. Problem is that in lit-html apps, probably most of the libraries operate via side-effects (they all register their own elements with the window).

This results in things like **empty files on `snowpack build`.** Obviously not great.

While disabling treeshaking isn‘t great, in a Web Component world I think it would be a better experience for most people. It at least opts people in to a better development setup by default.