### PR TITLE
Support `h` as the JSX pragma consistently throughout `app-scripts-preact`

### DIFF
--- a/packages/app-scripts-preact/jest/babelTransform.js
+++ b/packages/app-scripts-preact/jest/babelTransform.js
@@ -26,7 +26,12 @@ module.exports = babelJest.createTransformer({
         pragmaFrag: "Fragment",
       },
     ],
-    "@babel/preset-typescript",
+    [
+      "@babel/preset-typescript",
+      {
+        jsxPragma: "h",
+      },
+    ],
   ],
   plugins: ["@babel/plugin-syntax-import-meta"],
 });

--- a/packages/app-scripts-preact/tsconfig.base.json
+++ b/packages/app-scripts-preact/tsconfig.base.json
@@ -4,6 +4,7 @@
     "target": "esnext",
     "moduleResolution": "node",
     "jsx": "preserve",
+    "jsxFactory": "h",
     "baseUrl": "./",
     "paths": { "*": ["web_modules/.types/*"] },
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Adding `h` as the pragma to the base tsconfigfile allows typescript to find and use Preact's JSX type definitons instead of the nonexistent React bindings.

Adding it to Jest's babel configuration prevents it from mistakenly stripping the import of `h` as unused when reading a TSX file during testing.