### PR TITLE
Update react-refresh plugin instructions to run on development only

### DIFF
--- a/packages/plugin-react-refresh/README.md
+++ b/packages/plugin-react-refresh/README.md
@@ -18,9 +18,13 @@ In addition, you have to add `react-refresh/babel` as a plugin to your babel con
 ```js
 // babel.config.json
 {
-  "plugins": [
-    "react-refresh/babel"
-  ]
+  "env": {
+    "development": {
+      "plugins": [
+        "react-refresh/babel"
+      ]
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
React Refresh only works on development and throws on any other environment.
It's currently making `yarn build` fail after following the README instructions.

Ref: https://github.com/facebook/react/pull/15939