### PR TITLE
[webpack] Add logging to plugin

### DIFF
--- a/packages/plugin-webpack/plugin.js
+++ b/packages/plugin-webpack/plugin.js
@@ -29,7 +29,8 @@ module.exports = function plugin(config, args) {
   // Validate: args.outputPattern
   args.outputPattern = args.outputPattern || {};
   const jsOutputPattern = args.outputPattern.js || "js/[name].[contenthash].js";
-  const cssOutputPattern = args.outputPattern.css || "css/[name].[contenthash].css";
+  const cssOutputPattern =
+    args.outputPattern.css || "css/[name].[contenthash].css";
   const assetsOutputPattern =
     args.outputPattern.assets || "assets/[name]-[hash].[ext]";
   if (!jsOutputPattern.endsWith(".js")) {
@@ -67,12 +68,12 @@ module.exports = function plugin(config, args) {
 
       //Find all local script, use it as the entrypoint
       const scripts = Array.from(dom.window.document.querySelectorAll("script"))
-        .filter(el => el.type.trim().toLowerCase() === "module")
-        .filter(el => !/^[a-zA-Z]+:\/\//.test(el.src));
+        .filter((el) => el.type.trim().toLowerCase() === "module")
+        .filter((el) => !/^[a-zA-Z]+:\/\//.test(el.src));
 
       if (scripts.length === 0) {
         throw new Error("Can't bundle without script tag in html");
-        }
+      }
 
       const entries = {};
       for (const el of scripts) {
@@ -81,8 +82,8 @@ module.exports = function plugin(config, args) {
         const name = parsedPath.name;
         if (entries.name !== undefined) {
           throw new Error(`Duplicate script with name ${name}.`);
-      }
-        entries[name] = {path: path.join(srcDirectory, src), script: el};
+        }
+        entries[name] = { path: path.join(srcDirectory, src), script: el };
       }
 
       //Compile files using webpack
@@ -108,7 +109,11 @@ module.exports = function plugin(config, args) {
                     presets: [
                       [
                         "@babel/preset-env",
-                        { targets: presetEnvTargets, bugfixes: true },
+                        {
+                          targets: presetEnvTargets,
+                          bugfixes: true,
+                          modules: false,
+                        },
                       ],
                     ],
                   },
@@ -204,12 +209,20 @@ module.exports = function plugin(config, args) {
         });
       });
 
+      console.log(
+        stats.toString({
+          colors: true,
+          all: false,
+          assets: true,
+        })
+      );
+
       if (!args.skipFallbackOutput) {
-        const entrypoints = stats.toJson({assets: false, hash: true}).entrypoints;
+        const entrypoints = stats.toJson({ assets: false, hash: true })
+          .entrypoints;
 
         //Now that webpack is done, modify the html file to point to the newly compiled resources
-        Object.keys(entries).forEach(name => {
-
+        Object.keys(entries).forEach((name) => {
           if (entrypoints[name] !== undefined) {
             const assetFiles = chain(entrypoints, [name, "assets"]);
             const script = entries[name].script;


### PR DESCRIPTION
Resolves feedback brought up in https://github.com/pikapkg/create-snowpack-app/issues/152

- Runs format on the code
- Adds `modules: false,` to `babel/preset-env` usage. Not sure if required, but good to do just in case.
- Adds console.log to the final stats, so that webpack result isn't so opaque 


<img width="983" alt="Screen Shot 2020-06-23 at 1 09 34 PM" src="https://user-images.githubusercontent.com/622227/85455490-caa55500-b552-11ea-8d27-5ec5af960efd.png">
