### PR TITLE
[babel] set compact: false

### DIFF
--- a/packages/plugin-babel/plugin.js
+++ b/packages/plugin-babel/plugin.js
@@ -8,6 +8,7 @@ module.exports = function plugin(config, options) {
         filename: filePath,
         cwd: process.cwd(),
         ast: false,
+        compact: false,
       });
 
       return { result: result.code };


### PR DESCRIPTION
More follow ups from: https://github.com/pikapkg/create-snowpack-app/issues/152#issuecomment-648392689

The default "auto" setting will log an error if the file is a certain size. In dev, `compact` isn't very useful (it only removes whitespace) at the expense of readable output. In build, we let our bundlers do the optimizing for us.

<img width="1271" alt="Screen Shot 2020-06-23 at 1 28 42 PM" src="https://user-images.githubusercontent.com/622227/85457975-79e32b80-b555-11ea-8851-bc4dd576365b.png">
