### PR TITLE
[webpack] add corejs support to webpack plugin

### DIFF
--- a/packages/plugin-webpack/package.json
+++ b/packages/plugin-webpack/package.json
@@ -10,6 +10,7 @@
     "@open-wc/webpack-import-meta-loader": "^0.4.6",
     "babel-loader": "^8.1.0",
     "copy-webpack-plugin": "^6.0.1",
+    "core-js": "^3.5.0",
     "css-loader": "^3.5.3",
     "file-loader": "^6.0.0",
     "jsdom": "^16.2.2",

--- a/packages/plugin-webpack/plugin.js
+++ b/packages/plugin-webpack/plugin.js
@@ -113,6 +113,8 @@ module.exports = function plugin(config, args) {
                           targets: presetEnvTargets,
                           bugfixes: true,
                           modules: false,
+                          useBuiltIns: "usage",
+                          corejs: 3,
                         },
                       ],
                     ],

--- a/packages/plugin-webpack/plugin.js
+++ b/packages/plugin-webpack/plugin.js
@@ -9,16 +9,8 @@ const CopyPlugin = require("copy-webpack-plugin");
 const { JSDOM } = jsdom;
 const cwd = process.cwd();
 
-function chain(object, keys) {
-  let cur = object;
-  for (const key of keys) {
-    if (Object.keys(cur).includes(key)) {
-      cur = cur[key];
-    } else {
-      return undefined;
-    }
-  }
-  return cur;
+function insertAfter(newNode, existingNode) {
+  existingNode.parentNode.insertBefore(newNode, existingNode.nextSibling);
 }
 
 module.exports = function plugin(config, args) {
@@ -99,6 +91,7 @@ module.exports = function plugin(config, args) {
           rules: [
             {
               test: /\.js$/,
+              exclude: /node_modules/,
               use: [
                 {
                   loader: "babel-loader",
@@ -191,6 +184,7 @@ module.exports = function plugin(config, args) {
           entry,
           output: {
             path: destDirectory,
+            publicPath: baseUrl,
             filename: jsOutputPattern,
           },
         })
@@ -225,19 +219,23 @@ module.exports = function plugin(config, args) {
 
         //Now that webpack is done, modify the html file to point to the newly compiled resources
         Object.keys(entries).forEach((name) => {
-          if (entrypoints[name] !== undefined) {
-            const assetFiles = chain(entrypoints, [name, "assets"]);
-            const script = entries[name].script;
-            const jsFile = assetFiles.find((d) => d.endsWith(".js"));
-            const cssFile = assetFiles.find((d) => d.endsWith(".css"));
-            script.removeAttribute("type");
-            script.src = path.posix.join(baseUrl, jsFile);
-            if (cssFile) {
-              let csslink = dom.window.document.createElement("link");
-              csslink.setAttribute("rel", "stylesheet");
-              csslink.href = path.posix.join(baseUrl, cssFile);
-              dom.window.document.querySelector("head").append(csslink);
+          const originalScriptEl = entries[name].script;
+          if (entrypoints[name] !== undefined && entrypoints[name]) {
+            const assetFiles = entrypoints[name].assets || [];
+            const jsFiles = assetFiles.filter((d) => d.endsWith(".js"));
+            const cssFiles = assetFiles.filter((d) => d.endsWith(".css"));
+            for (const jsFile of jsFiles) {
+              const scriptEl = dom.window.document.createElement("script");
+              scriptEl.src = path.posix.join(baseUrl, jsFile);
+              insertAfter(scriptEl, originalScriptEl);
             }
+            for (const cssFile of cssFiles) {
+              const linkEl = dom.window.document.createElement("link");
+              linkEl.setAttribute("rel", "stylesheet");
+              linkEl.href = path.posix.join(baseUrl, cssFile);
+              dom.window.document.querySelector("head").append(linkEl);
+            }
+            originalScriptEl.remove();
           }
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5032,15 +5032,15 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
-core-js@^2.4.0, core-js@^2.6.5:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
-  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
-
 core-js@^3.5.0:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
+
+core-js@^2.4.0, core-js@^2.6.5:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
+  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Another follow up from #152 !

Our bundler plugin currently transpiles for your target browser, but it doesn't actually polyfill anything that it knows would be missing in that environment. This PR enabled automatic polyfilling for anything not supported by the target.

We use `useBuiltIns: 'usage'` so that this is automatic, and no `import "core-js"` statements are needed in your source code or unnecessarily installed during dev.
