### PR TITLE
support multiple html webpack entries

### DIFF
--- a/packages/plugin-webpack/package.json
+++ b/packages/plugin-webpack/package.json
@@ -13,6 +13,7 @@
     "core-js": "^3.5.0",
     "css-loader": "^3.5.3",
     "file-loader": "^6.0.0",
+    "glob": "^7.1.6",
     "jsdom": "^16.2.2",
     "mini-css-extract-plugin": "^0.9.0",
     "optimize-css-assets-webpack-plugin": "^5.0.3",

--- a/packages/plugin-webpack/plugin.js
+++ b/packages/plugin-webpack/plugin.js
@@ -1,5 +1,7 @@
 const fs = require("fs");
+const glob = require("glob");
 const path = require("path");
+const util = require("util");
 const webpack = require("webpack");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const TerserJSPlugin = require("terser-webpack-plugin");
@@ -8,6 +10,8 @@ const jsdom = require("jsdom");
 const CopyPlugin = require("copy-webpack-plugin");
 const { JSDOM } = jsdom;
 const cwd = process.cwd();
+
+const globAsync = util.promisify(glob);
 
 function insertAfter(newNode, existingNode) {
   existingNode.parentNode.insertBefore(newNode, existingNode.nextSibling);
@@ -54,28 +58,38 @@ module.exports = function plugin(config, args) {
         extendConfig = (cfg) => ({ ...cfg, ...args.extendConfig });
       }
 
-      let dom = new JSDOM(
-        fs.readFileSync(path.join(srcDirectory, config.devOptions.fallback))
-      );
+      // Get all html files from the output folder
+      const pattern = srcDirectory + "/**/*.html";
+      const htmlFiles = (await globAsync(pattern))
+          .map(htmlPath => path.relative(srcDirectory, htmlPath));
 
-      //Find all local script, use it as the entrypoint
-      const scripts = Array.from(dom.window.document.querySelectorAll("script"))
-        .filter((el) => el.type.trim().toLowerCase() === "module")
-        .filter((el) => !/^[a-zA-Z]+:\/\//.test(el.src));
+      const doms = {};
+      const entries = {};
+      for (const htmlFile of htmlFiles) {
+          const dom = new JSDOM(
+            fs.readFileSync(path.join(srcDirectory, htmlFile))
+          );
 
-      if (scripts.length === 0) {
-        throw new Error("Can't bundle without script tag in html");
+          //Find all local script, use it as the entrypoint
+          const scripts = Array.from(dom.window.document.querySelectorAll("script"))
+            .filter((el) => el.type.trim().toLowerCase() === "module")
+            .filter((el) => !/^[a-zA-Z]+:\/\//.test(el.src));
+
+          for (const el of scripts) {
+            const src = el.src.trim();
+            const parsedPath = path.parse(src);
+            const name = parsedPath.name;
+            if (!(name in entries)) {
+                entries[name] = { path: path.join(srcDirectory, src), occurrences: [] };
+            }
+            entries[name].occurrences.push({ script: el, dom });
+          }
+
+          doms[htmlFile] = dom;
       }
 
-      const entries = {};
-      for (const el of scripts) {
-        const src = el.src.trim();
-        const parsedPath = path.parse(src);
-        const name = parsedPath.name;
-        if (entries.name !== undefined) {
-          throw new Error(`Duplicate script with name ${name}.`);
-        }
-        entries[name] = { path: path.join(srcDirectory, src), script: el };
+      if (Object.keys(entries).length === 0) {
+        throw new Error("Can't bundle without script tag in html");
       }
 
       //Compile files using webpack
@@ -222,33 +236,40 @@ module.exports = function plugin(config, args) {
         const entrypoints = stats.toJson({ assets: false, hash: true })
           .entrypoints;
 
-        //Now that webpack is done, modify the html file to point to the newly compiled resources
+        //Now that webpack is done, modify the html files to point to the newly compiled resources
         Object.keys(entries).forEach((name) => {
-          const originalScriptEl = entries[name].script;
           if (entrypoints[name] !== undefined && entrypoints[name]) {
             const assetFiles = entrypoints[name].assets || [];
             const jsFiles = assetFiles.filter((d) => d.endsWith(".js"));
             const cssFiles = assetFiles.filter((d) => d.endsWith(".css"));
-            for (const jsFile of jsFiles) {
-              const scriptEl = dom.window.document.createElement("script");
-              scriptEl.src = path.posix.join(baseUrl, jsFile);
-              insertAfter(scriptEl, originalScriptEl);
+
+            for (const occurrence of entries[name].occurrences) {
+              const originalScriptEl = occurrence.script;
+              const dom = occurrence.dom;
+
+              for (const jsFile of jsFiles) {
+                const scriptEl = dom.window.document.createElement("script");
+                scriptEl.src = path.posix.join(baseUrl, jsFile);
+                insertAfter(scriptEl, originalScriptEl);
+              }
+              for (const cssFile of cssFiles) {
+                const linkEl = dom.window.document.createElement("link");
+                linkEl.setAttribute("rel", "stylesheet");
+                linkEl.href = path.posix.join(baseUrl, cssFile);
+                dom.window.document.querySelector("head").append(linkEl);
+              }
+              originalScriptEl.remove();
             }
-            for (const cssFile of cssFiles) {
-              const linkEl = dom.window.document.createElement("link");
-              linkEl.setAttribute("rel", "stylesheet");
-              linkEl.href = path.posix.join(baseUrl, cssFile);
-              dom.window.document.querySelector("head").append(linkEl);
-            }
-            originalScriptEl.remove();
           }
         });
 
-        //And write our modified html file out to the destination
-        fs.writeFileSync(
-          path.join(destDirectory, config.devOptions.fallback),
-          dom.serialize()
-        );
+        //And write our modified html files out to the destination
+        for (const [htmlFile, dom] of Object.entries(doms)) {
+            fs.writeFileSync(
+              path.join(destDirectory, htmlFile),
+              dom.serialize()
+            );
+        }
       }
     },
   };

--- a/packages/plugin-webpack/plugin.js
+++ b/packages/plugin-webpack/plugin.js
@@ -243,6 +243,7 @@ module.exports = function plugin(config, args) {
             for (const occurrence of entries[name].occurrences) {
               const originalScriptEl = occurrence.script;
               const dom = occurrence.dom;
+              const head = dom.window.document.querySelector("head");
 
               for (const jsFile of jsFiles) {
                 const scriptEl = dom.window.document.createElement("script");
@@ -253,7 +254,7 @@ module.exports = function plugin(config, args) {
                 const linkEl = dom.window.document.createElement("link");
                 linkEl.setAttribute("rel", "stylesheet");
                 linkEl.href = path.posix.join(baseUrl, cssFile);
-                dom.window.document.querySelector("head").append(linkEl);
+                head.append(linkEl);
               }
               originalScriptEl.remove();
             }

--- a/packages/plugin-webpack/plugin.js
+++ b/packages/plugin-webpack/plugin.js
@@ -1,7 +1,6 @@
 const fs = require("fs");
 const glob = require("glob");
 const path = require("path");
-const util = require("util");
 const webpack = require("webpack");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const TerserJSPlugin = require("terser-webpack-plugin");
@@ -10,8 +9,6 @@ const jsdom = require("jsdom");
 const CopyPlugin = require("copy-webpack-plugin");
 const { JSDOM } = jsdom;
 const cwd = process.cwd();
-
-const globAsync = util.promisify(glob);
 
 function insertAfter(newNode, existingNode) {
   existingNode.parentNode.insertBefore(newNode, existingNode.nextSibling);
@@ -60,7 +57,7 @@ module.exports = function plugin(config, args) {
 
       // Get all html files from the output folder
       const pattern = srcDirectory + "/**/*.html";
-      const htmlFiles = (await globAsync(pattern))
+      const htmlFiles = glob.sync(pattern)
           .map(htmlPath => path.relative(srcDirectory, htmlPath));
 
       const doms = {};

--- a/packages/plugin-webpack/plugin.js
+++ b/packages/plugin-webpack/plugin.js
@@ -229,45 +229,43 @@ module.exports = function plugin(config, args) {
         );
       }
 
-      if (!args.skipFallbackOutput) {
-        const entrypoints = stats.toJson({ assets: false, hash: true })
-          .entrypoints;
+      const entrypoints = stats.toJson({ assets: false, hash: true })
+        .entrypoints;
 
-        //Now that webpack is done, modify the html files to point to the newly compiled resources
-        Object.keys(entries).forEach((name) => {
-          if (entrypoints[name] !== undefined && entrypoints[name]) {
-            const assetFiles = entrypoints[name].assets || [];
-            const jsFiles = assetFiles.filter((d) => d.endsWith(".js"));
-            const cssFiles = assetFiles.filter((d) => d.endsWith(".css"));
+      //Now that webpack is done, modify the html files to point to the newly compiled resources
+      Object.keys(entries).forEach((name) => {
+        if (entrypoints[name] !== undefined && entrypoints[name]) {
+          const assetFiles = entrypoints[name].assets || [];
+          const jsFiles = assetFiles.filter((d) => d.endsWith(".js"));
+          const cssFiles = assetFiles.filter((d) => d.endsWith(".css"));
 
-            for (const occurrence of entries[name].occurrences) {
-              const originalScriptEl = occurrence.script;
-              const dom = occurrence.dom;
-              const head = dom.window.document.querySelector("head");
+          for (const occurrence of entries[name].occurrences) {
+            const originalScriptEl = occurrence.script;
+            const dom = occurrence.dom;
+            const head = dom.window.document.querySelector("head");
 
-              for (const jsFile of jsFiles) {
-                const scriptEl = dom.window.document.createElement("script");
-                scriptEl.src = path.posix.join(baseUrl, jsFile);
-                insertAfter(scriptEl, originalScriptEl);
-              }
-              for (const cssFile of cssFiles) {
-                const linkEl = dom.window.document.createElement("link");
-                linkEl.setAttribute("rel", "stylesheet");
-                linkEl.href = path.posix.join(baseUrl, cssFile);
-                head.append(linkEl);
-              }
-              originalScriptEl.remove();
+            for (const jsFile of jsFiles) {
+              const scriptEl = dom.window.document.createElement("script");
+              scriptEl.src = path.posix.join(baseUrl, jsFile);
+              insertAfter(scriptEl, originalScriptEl);
             }
+            for (const cssFile of cssFiles) {
+              const linkEl = dom.window.document.createElement("link");
+              linkEl.setAttribute("rel", "stylesheet");
+              linkEl.href = path.posix.join(baseUrl, cssFile);
+              head.append(linkEl);
+            }
+            originalScriptEl.remove();
           }
-        });
-
-        //And write our modified html files out to the destination
-        for (const [htmlFile, dom] of Object.entries(doms)) {
-            fs.writeFileSync(
-              path.join(destDirectory, htmlFile),
-              dom.serialize()
-            );
         }
+      });
+
+      //And write our modified html files out to the destination
+      for (const [htmlFile, dom] of Object.entries(doms)) {
+          fs.writeFileSync(
+            path.join(destDirectory, htmlFile),
+            dom.serialize()
+          );
       }
     },
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6818,7 +6818,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==


### PR DESCRIPTION
Fixes #74.

Instead of extracting script tags from `config.devOptions.fallback`, I search for all *.html files in the build directory and extract local script tags from all of them.