### PR TITLE
Enable "useDefineForClassFields" in tsconfig

### DIFF
--- a/templates/app-template-blank-typescript/tsconfig.json
+++ b/templates/app-template-blank-typescript/tsconfig.json
@@ -13,6 +13,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
+    "useDefineForClassFields": true,
     
     // You can't currently define paths in your 'extends' config,
     // so we have to set 'baseUrl' & 'paths' here.


### PR DESCRIPTION
This option `"useDefineForClassFields": true` combined with `"target": "esnext"` ensures that modern class syntax is emitted.

This option ensures browser and Node semantics are respected.
Without this option, TypeScript will down-level class field declarations into constructor assignments.

Example input:  `class C { field = 1; }`
- Output before this change: `class C { constructor() { this.field = 1; } }`
- Output with this change: `class C { field = 1; }`

You can test this in the TypeScript playground.
  https://www.typescriptlang.org/play/index.html?target=99#code/LAKFGMBsEMGdYAQGEEG8EDMCWBTSATBAXgQEYEBfIA