### PR TITLE
Announce migration to pikapkg/snowpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,5 @@
-# Create Snowpack App (CSA)
+# Moved
 
-```
-npx create-snowpack-app new-dir --template @snowpack/app-template-NAME [--use-yarn | --use-pnpm]
-```
+All official templates and plugins have moved into the main Snowpack repository:
 
-## Official App Templates
-
-- [@snowpack/app-template-blank](/templates/app-template-blank)
-- [@snowpack/app-template-blank-typescript](/templates/app-template-blank-typescript)
-- [@snowpack/app-template-11ty](/templates/app-template-11ty)
-- [@snowpack/app-template-lit-element-typescript](/templates/app-template-lit-element-typescript)
-- [@snowpack/app-template-lit-element](/templates/app-template-lit-element)
-- [@snowpack/app-template-preact](/templates/app-template-preact)
-- [@snowpack/app-template-react-typescript](/templates/app-template-react-typescript)
-- [@snowpack/app-template-react](/templates/app-template-react)
-- [@snowpack/app-template-svelte](/templates/app-template-svelte)
-- [@snowpack/app-template-vue](/templates/app-template-vue)
-
-### Featured Community Templates
-
-- [snowpack-template-preset-env](https://github.com/argyleink/snowpack-template-preset-env) (PostCSS + Babel)
-- [11st-Starter-Kit](https://github.com/stefanfrede/11st-starter-kit) (11ty +
-  Snowpack + tailwindcss)
-- [app-template-reason-react](https://github.com/jihchi/app-template-reason-react) (ReasonML (BuckleScript) & reason-react on top of [@snowpack/app-template-react](/templates/app-template-react))
-- [svelte-tailwind](https://github.com/agneym/svelte-tailwind-snowpack) (Adds PostCSS and TailwindCSS using [svelte-preprocess](https://github.com/sveltejs/svelte-preprocess))
-- [snowpack-react-tailwind](https://github.com/mrkldshv/snowpack-react-tailwind) (React + Snowpack + Tailwindcss)
-- PRs that add a link to this list are welcome!
-
-## Official Snowpack Plugins
-
-### Dev Environment
-
-- [@snowpack/plugin-dotenv](/packages/plugin-dotenv)
-
-### Build
-
-- [@snowpack/plugin-babel](/packages/plugin-babel)
-- [@snowpack/plugin-svelte](/packages/plugin-svelte)
-- [@snowpack/plugin-vue](/packages/plugin-vue)
-
-### Transform
-
-- [@snowpack/plugin-react-refresh](/packages/plugin-react-refresh)
-
-### Bundle
-
-- [@snowpack/plugin-parcel](/packages/plugin-parcel)
-- [@snowpack/plugin-webpack](/packages/plugin-webpack)
-
-### Featured Community Plugins
-
-- [@prefresh/snowpack](https://github.com/JoviDeCroock/prefresh)
-- [snowpack-plugin-import-map](https://github.com/zhoukekestar/snowpack-plugin-import-map) A more easy way to map your imports to Pika CDN instead of [import-maps.json](https://github.com/WICG/import-maps).
-- PRs that add a link to this list are welcome!
+https://github.com/pikapkg/snowpack/tree/master/packages/create-snowpack-app.


### PR DESCRIPTION
Links to project’s new home: https://github.com/pikapkg/snowpack/tree/master/packages/create-snowpack-app. As discussed in https://github.com/pikapkg/snowpack/pull/619 and https://github.com/pikapkg/snowpack/pull/625, this lets us now test Snowpack core changes against plugins, and vice-versa, without having to deploy to npm. This (hopefully) will simplify contribution as well as local testing.